### PR TITLE
svg files now are non-tracked files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ yarn-error.log
 .idea/workspace.xml
 /idea/*.xml
 /report
+/public/icons/*.svg


### PR DESCRIPTION
Everytime `vendor/bin/phpunit` is executed, svg icons are generated. So, by add this gitignore line, no more icons will be appear in stage changes.